### PR TITLE
follow Node callback convention, request -> fetch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 Query the [overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API). Returns a GeoJSON collection.
 
-**WORKS ONLY IN NODE as it uses [request](https://www.npmjs.com/package/request) to fetch the data.**
-For use in the browser, see [idris-overpass-browser](https://www.npmjs.com/package/idris-overpass-browser)
-
 ## Usage
 
 **io(config, callback)**

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # idris-overpass
 
-Query the [overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API). Returns a GeoJSON collection.
+Query the [overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API). Returns a GeoJSON collection, takes an [error-first callback](http://fredkschott.com/post/2014/03/understanding-error-first-callbacks-in-node-js/).
 
 ## Usage
 
-**io(config, callback)**
+**queryOverpass(config, callback)**
 
 ```
-var io = require('idris-overpass')
+var queryOverpass = require('idris-overpass')
 
 var config = {
 	bbox: [7.590,47.560,7.595,47.563],
 	kv: [{key: 'highway', value: '*'}]
 }
 
-io(config, function(geojson) {
-	console.log(geojson)
+queryOverpass(config, function(err, geojson) {
+	if (err) console.error(err)
+	else console.log(geojson)
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var request = require('request')
+var Promise = require('pinkie-promise')
+var fetch = require('fetch-ponyfill')({Promise: Promise}).fetch
 var osmtogeojson = require('osmtogeojson')
 
 module.exports = function(input, callback) {
@@ -44,12 +45,23 @@ function createUrl(bb, keyVals, timeout) {
 }
 
 function reqUrl(url, callback) {
-	request(url, function (error, response, body) {
-		if (!error && response.statusCode == 200) {
-			callback(JSON.parse(body))
-		} else {
-			console.log('request ERROR', error)
-			console.log('request STATUSCODE', response.statusCode)
+	fetch(url, {
+		mode: 'cors',
+		redirect: 'follow'
+	})
+	.then(function (res) {
+		if (!res.ok) {
+			var err = new Error(res.statusText)
+			err.statusCode = res.status
+			throw err
 		}
+		return res.json()
+	})
+	.then(function (body) {
+		callback(body)
+	})
+	.catch(function (error) {
+		console.log('request ERROR', error.message)
+		console.log('request STATUSCODE', response.statusCode)
 	})
 }

--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ var osmtogeojson = require('osmtogeojson')
 module.exports = function(input, callback) {
 	var data = checkInput(input)
 	var url = createUrl(data.bbox, data.kv, data.timeout)
-	reqUrl(url, function(json) { 
+	reqUrl(url, function(err, json) { 
+		if (err) return callback(err)
 		var geojson = osmtogeojson(json, { flatProperties: true })
-		callback(geojson)
+		callback(null, geojson)
 	})
 }
 
@@ -58,10 +59,7 @@ function reqUrl(url, callback) {
 		return res.json()
 	})
 	.then(function (body) {
-		callback(body)
+		callback(null, body)
 	})
-	.catch(function (error) {
-		console.log('request ERROR', error.message)
-		console.log('request STATUSCODE', response.statusCode)
-	})
+	.catch(callback)
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   "author": "idris-maps",
   "license": "GPL-2.0",
   "dependencies": {
+    "fetch-ponyfill": "^4.0.0",
     "osmtogeojson": "^2.2.12",
-    "request": "^2.79.0"
+    "pinkie-promise": "^2.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
following the [Node callback convention](http://fredkschott.com/post/2014/03/understanding-error-first-callbacks-in-node-js/) aligns this repo with the majority of callback-based JavaScript out there and therefore lowers the mental barrier to use it.

**Note that this is a breaking change.**

[`fetch` API (which is native) along with the polyfill](https://www.npmjs.com/package/fetch-ponyfill) is more lightweight than `request`. This change makes this repo be [isomorphic, which means it runs in both Node and the browser](https://en.wikipedia.org/wiki/Isomorphic_JavaScript).